### PR TITLE
Always print decimal

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -644,17 +644,11 @@ void Adafruit_7segment::printFloat(double n, uint8_t fracDigits, uint8_t base)
     // otherwise, display the number
     int8_t displayPos = 4;
     
-    if (displayNumber)  //if displayNumber is not 0
-    {
-      for(uint8_t i = 0; displayNumber || i <= fracDigits; ++i) {
-        boolean displayDecimal = (fracDigits != 0 && i == fracDigits);
-        writeDigitNum(displayPos--, displayNumber % base, displayDecimal);
-        if(displayPos == 2) writeDigitRaw(displayPos--, 0x00);
-        displayNumber /= base;
-      }
-    }
-    else {
-      writeDigitNum(displayPos--, 0, false);
+    for(uint8_t i = 0; displayNumber || i <= fracDigits; ++i) {
+      boolean displayDecimal = (fracDigits != 0 && i == fracDigits);
+      writeDigitNum(displayPos--, displayNumber % base, displayDecimal);
+      if(displayPos == 2) writeDigitRaw(displayPos--, 0x00);
+      displayNumber /= base;
     }
   
     // display negative sign if negative


### PR DESCRIPTION
Always prints the fractional digit(s) for a floating point number, if specified (>0).